### PR TITLE
Don't remove values from session while unpacking

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,20 @@ any way with the different client registration modes.
   about the client. The `redirect_uris` registered with the provider MUST include
   `<flask_url>/redirect_uri`, where `<flask_url>` is the URL for the Flask application.
 
+## Configuration
+
 The application using this extension MUST set the following [builtin configuration values of Flask](http://flask.pocoo.org/docs/0.10/config/#builtin-configuration-values):
 
-* `SERVER_NAME` (MUST be the same as `<flask_url>` if using static client registration
-* `SECRET_KEY` (this extension relies on Flask session, which requires `SECRET_KEY`)
+* `SERVER_NAME` (MUST be the same as `<flask_url>` if using static client registration)
+* `SECRET_KEY` (this extension relies on [Flask sessions](http://flask.pocoo.org/docs/0.11/quickstart/#sessions), which requires `SECRET_KEY`)
+
+You may also configure the way Flask sessions handles the user session:
+
+* `PERMANENT_SESSION` (added by this extension; makes the session cookie expire after a configurable length of time instead of being tied to the browser session)
+* `PERMANENT_SESSION_LIFETIME` (the lifetime of a permanent session)
+
+See the [Flask documentation](http://flask.pocoo.org/docs/0.11/config/#builtin-configuration-values) for an exhaustive list of configuration options.
+
+## Example
 
 Have a look at the example Flask app in [app.py](example/app.py) for an idea of how to use it.

--- a/src/flask_pyoidc/flask_pyoidc.py
+++ b/src/flask_pyoidc/flask_pyoidc.py
@@ -131,12 +131,11 @@ class OIDCAuthentication(object):
         return wrapper
 
     def _unpack_user_session(self):
-        flask.g.id_token = IdToken().from_dict(flask.session.pop('id_token'))
-        flask.g.access_token = flask.session.pop('access_token', None)
-        userinfo_dict = flask.session.pop('userinfo', None)
+        flask.g.id_token = IdToken().from_dict(flask.session.get('id_token'))
+        flask.g.access_token = flask.session.get('access_token', None)
+        userinfo_dict = flask.session.get('userinfo', None)
         if userinfo_dict:
             flask.g.userinfo = OpenIDSchema().from_dict(userinfo_dict)
-
     def _logout(self):
         id_token_jwt = flask.session['id_token_jwt']
         flask.session.clear()

--- a/src/flask_pyoidc/flask_pyoidc.py
+++ b/src/flask_pyoidc/flask_pyoidc.py
@@ -4,8 +4,7 @@ import flask
 from flask.helpers import url_for
 from oic import rndstr
 from oic.oic import Client
-from oic.oic.message import ProviderConfigurationResponse, RegistrationRequest, \
-    AuthorizationResponse, IdToken, OpenIDSchema, EndSessionRequest
+from oic.oic.message import ProviderConfigurationResponse, RegistrationRequest, AuthorizationResponse, EndSessionRequest
 from oic.utils.authn.client import CLIENT_AUTHN_METHOD
 from werkzeug.utils import redirect
 
@@ -122,9 +121,6 @@ class OIDCAuthentication(object):
         @functools.wraps(view_func)
         def wrapper(*args, **kwargs):
             if not self._reauthentication_necessary(flask.session.get('id_token')):
-                # fetch user session and make accessible for view function
-                self._unpack_user_session()
-
                 # make the session permanent if the user has chosen to configure a custom lifetime
                 if self.app.config.get('PERMANENT_SESSION', False):
                     flask.session.permanent = True
@@ -135,12 +131,6 @@ class OIDCAuthentication(object):
 
         return wrapper
 
-    def _unpack_user_session(self):
-        flask.g.id_token = IdToken().from_dict(flask.session.get('id_token'))
-        flask.g.access_token = flask.session.get('access_token', None)
-        userinfo_dict = flask.session.get('userinfo', None)
-        if userinfo_dict:
-            flask.g.userinfo = OpenIDSchema().from_dict(userinfo_dict)
     def _logout(self):
         id_token_jwt = flask.session['id_token_jwt']
         flask.session.clear()

--- a/src/flask_pyoidc/flask_pyoidc.py
+++ b/src/flask_pyoidc/flask_pyoidc.py
@@ -124,6 +124,11 @@ class OIDCAuthentication(object):
             if not self._reauthentication_necessary(flask.session.get('id_token')):
                 # fetch user session and make accessible for view function
                 self._unpack_user_session()
+
+                # make the session permanent if the user has chosen to configure a custom lifetime
+                if self.app.config.get('PERMANENT_SESSION', False):
+                    flask.session.permanent = True
+
                 return view_func(*args, **kwargs)
 
             return self._authenticate()


### PR DESCRIPTION
After the user logs in, their session is unpacked from the Flask `session` object and copied into the `g` object. However, the values were being popped, leaving an empty session object which Flask helpfully garbage collected. As a result, the user would be redirected to the IdP on every request to the application, which not only added a large number of redirects on every page load but broke any non-GET and XHR requests that the page or application tried to make.

This PR changes the method calls in `_unpack_user_session` to `get()` values from the Flask session object instead of `pop()`ing them.