### PR TITLE
Pass arguments through the oidc_auth wrapper

### DIFF
--- a/src/flask_pyoidc/flask_pyoidc.py
+++ b/src/flask_pyoidc/flask_pyoidc.py
@@ -112,11 +112,11 @@ class OIDCAuthentication(object):
 
     def oidc_auth(self, view_func):
         @functools.wraps(view_func)
-        def wrapper():
+        def wrapper(*args, **kwargs):
             if not self._reauthentication_necessary(flask.session.get('id_token')):
                 # fetch user session and make accessible for view function
                 self._unpack_user_session()
-                return view_func()
+                return view_func(*args, **kwargs)
 
             return self._authenticate()
 


### PR DESCRIPTION
The `oidc_auth` decorator did not accept or pass through any arguments to the wrapped route, resulting in an `wrapper() got an unexpected keyword argument` error when the wrapped function expected arguments (e.g. from a variable in the route URL).

This PR changes the `wrapper()` function to both accept any number of arguments and keyword arguments and pass them through to the wrapped function when the user is authenticated, as per the official documentation: http://flask.pocoo.org/docs/0.11/patterns/viewdecorators/