### PR TITLE
Add support for RP-Initiated logout.

### DIFF
--- a/example/app.py
+++ b/example/app.py
@@ -18,5 +18,11 @@ def index():
                    userinfo=flask.g.userinfo.to_dict())
 
 
+@app.route('/logout')
+@auth.oidc_logout
+def logout():
+    return 'You\'ve been successfully logged out!'
+
+
 if __name__ == '__main__':
     app.run(port=PORT)

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
         author_email='rebecka.gulliksson@umu.se',
         description='Flask extension for OpenID Connect authentication.',
         install_requires=[
-            'oic==0.8.3',
+            'oic==0.9.1.0',
             'Flask'
         ]
 )


### PR DESCRIPTION
As described in http://openid.net/specs/openid-connect-session-1_0.html#RPLogout and discussed in #4.
Requires https://github.com/rohe/pyoidc/pull/227.

@stevenmirabito: I'd like to get your feedback if this works for your use case.