### PR TITLE
Add logout view to post_logout_redirect_uris regardless of dynamic registration

### DIFF
--- a/src/flask_pyoidc/flask_pyoidc.py
+++ b/src/flask_pyoidc/flask_pyoidc.py
@@ -45,13 +45,14 @@ class OIDCAuthentication(object):
     def _authenticate(self):
         if 'client_id' not in self.client_registration_info:
             # do dynamic registration
-            if self.logout_view:
-                # handle support for logout
-                with self.app.app_context():
-                    self.client_registration_info['post_logout_redirect_uris'] = [url_for(self.logout_view.__name__,
-                                                                                          _external=True)]
             self.client.register(self.client.provider_info['registration_endpoint'],
                                  **self.client_registration_info)
+
+        if self.logout_view:
+            # handle support for logout
+            with self.app.app_context():
+                self.client_registration_info['post_logout_redirect_uris'] = [url_for(self.logout_view.__name__,
+                                                                                      _external=True)]
 
         flask.session['destination'] = flask.request.url
         flask.session['state'] = rndstr()


### PR DESCRIPTION
This is something I just came across as I don't use dynamic registration. I'm not sure if this is the correct way to do this (you could also say if you're using manual registration you have to register the logout endpoint in `client_registration_info` manually as well), but considering that `logout_view` is registered through the use of the `@oidc_logout` decorator in the application I think it makes sense to register it automatically.